### PR TITLE
Remove Tiger-only requirement for apple-gcc4.2

### DIFF
--- a/Library/Formula/apple-gcc42.rb
+++ b/Library/Formula/apple-gcc42.rb
@@ -1,23 +1,11 @@
 require 'formula'
 
-class TigerOnly < Requirement
-  def message; <<-EOS.undent
-    gcc-4.2 is only provided for Tiger, as it is officially available
-    from an Xcode shipped with Leopard.
-    EOS
-  end
-  def satisfied?; MacOS.version == :tiger; end
-  def fatal?; true; end
-end
-
 class AppleGcc42 < Formula
   homepage 'http://r.research.att.com/tools/'
   url 'https://ia902307.us.archive.org/31/items/tigerbrew/gcc-42-5553-darwin8-all.tar.gz'
   mirror 'http://r.research.att.com/gcc-42-5553-darwin8-all.tar.gz'
   version '4.2.1-5553'
   sha1 '0e529a2e4723e016e3d086d6ca3215d700931503'
-
-  depends_on TigerOnly.new
 
   def install
     cd 'usr' do


### PR DESCRIPTION
GCC 4.2 isn't offered through Xcode 3.1.4, the latest version of Xcode available for Leopard. That still shipped with Apple's GCC 4.0.1.

Xcode 3.2.x was the first to include GCC 4.2.x. Xcode 3.2 cannot be installed on any Mac OS X before Snow Leopard.

Unfortunately, this version check isn't very useful for Leopard on PPC users. Removing it, it installs and runs fine on Leopard PPC.

Happy to back away from this change, if there is indeed another means of having GCC 4.2 on Leopard minus the Snow. I couldn't find it on http://developer.apple.com/download/more/ .